### PR TITLE
Minor fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -129,7 +129,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -650,7 +650,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -695,10 +695,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.5"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31a0499c1dc64f458ad13872de75c0eb7e3fdb0e67964610c914b034fc5956e"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -964,7 +965,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -978,7 +979,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -989,7 +990,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1000,7 +1001,7 @@ checksum = "e79f8e61677d5df9167cd85265f8e5f64b215cdea3fb55eebc3e622e44c7a146"
 dependencies = [
  "darling_core 0.21.0",
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1149,6 +1150,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -2424,7 +2431,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2482,7 +2489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2667,7 +2674,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2959,9 +2966,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.13.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1863fd3768cd83c56a7f60faa4dc0d403f1b6df0a38c3c25f44b7894e45370d5"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3013,17 +3020,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.91",
-]
-
-[[package]]
 name = "serde_json"
 version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3033,6 +3029,17 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -3076,7 +3083,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -3287,7 +3294,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -3688,7 +3695,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
  "wasm-bindgen-shared",
 ]
 
@@ -3723,7 +3730,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3793,7 +3800,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -3804,7 +3811,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,7 @@ dependencies = [
  "clap",
  "clap_derive",
  "confidential_signer",
- "serde",
+ "signer_core",
 ]
 
 [[package]]
@@ -2214,7 +2214,7 @@ dependencies = [
  "clap",
  "clap_derive",
  "nitro_signer",
- "serde",
+ "signer_core",
 ]
 
 [[package]]

--- a/ale/src/lib.rs
+++ b/ale/src/lib.rs
@@ -54,6 +54,11 @@ impl<'a> Stream<'a> {
     }
 
     #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    #[inline]
     fn get_bytes(&mut self, len: usize) -> Result<&'a [u8], Error> {
         if self.inner.len() < len {
             Err(Error::EOS)
@@ -66,7 +71,7 @@ impl<'a> Stream<'a> {
 
     #[inline]
     fn get_u8(&mut self) -> Result<u8, Error> {
-        if self.inner.len() < 1 {
+        if self.inner.is_empty() {
             Err(Error::EOS)
         } else {
             let v = self.inner[0];
@@ -207,10 +212,7 @@ impl Elem {
 
     #[inline]
     pub fn available(&self, stream: &Stream) -> Option<usize> {
-        match self.len {
-            Some(len) => Some(len - self.consumed(stream)),
-            None => None,
-        }
+        self.len.map(|len| len - self.consumed(stream))
     }
 
     pub fn get_elem(
@@ -274,7 +276,7 @@ impl Elem {
         if stream.peek_tag()? == expect {
             self.get_elem(stream, None)
         } else {
-            return Ok(None);
+            Ok(None)
         }
     }
 

--- a/ale/src/lib.rs
+++ b/ale/src/lib.rs
@@ -333,7 +333,7 @@ impl std::fmt::Display for Error {
         match self {
             Error::EOS => f.write_str("unexpected end of stream"),
             Error::ValueTooLarge => f.write_str("value is too large"),
-            Error::Encoding => f.write_str("invalid error"),
+            Error::Encoding => f.write_str("invalid encoding"),
             Error::Tag(tag) => write!(f, "unexpected tag: {:x}", tag),
             Error::Infinite => f.write_str("infinite length"),
             Error::Convert(err) => write!(f, "convert error: {}", err),

--- a/confidential_signer/src/error.rs
+++ b/confidential_signer/src/error.rs
@@ -4,6 +4,7 @@ pub enum Error {
     Auth(google_cloud_gax::client_builder::Error),
     Encryption(google_cloud_gax::error::Error),
     Decryption(google_cloud_gax::error::Error),
+    CredentialFormat(String),
 }
 
 impl std::fmt::Display for Error {
@@ -13,6 +14,7 @@ impl std::fmt::Display for Error {
             Error::Auth(e) => write!(f, "Auth error: {}", e),
             Error::Encryption(e) => write!(f, "Encryption error: {}", e),
             Error::Decryption(e) => write!(f, "Decryption error: {}", e),
+            Error::CredentialFormat(msg) => write!(f, "Credential format error: {}", msg),
         }
     }
 }
@@ -24,6 +26,7 @@ impl std::error::Error for Error {
             Error::Auth(e) => Some(e),
             Error::Encryption(e) => Some(e),
             Error::Decryption(e) => Some(e),
+            Error::CredentialFormat(_) => None,
         }
     }
 }

--- a/confidential_signer/src/kms_client.rs
+++ b/confidential_signer/src/kms_client.rs
@@ -76,10 +76,11 @@ impl EncryptionBackendFactory for ClientFactory {
         &self,
         credentials: Self::Credentials,
     ) -> Result<Self::Output, <Self::Output as EncryptionBackend>::Error> {
-        // prepare credentials file
         let credentials_json_str =
-            strfmt!(CONFIDENTIAL_CONFIG_STR, wip_provider_path => credentials.wip_provider_path).unwrap();
-        let credentials_json = serde_json::from_str(&credentials_json_str).unwrap();
+            strfmt!(CONFIDENTIAL_CONFIG_STR, wip_provider_path => credentials.wip_provider_path)
+                .map_err(|e| error::Error::CredentialFormat(e.to_string()))?;
+        let credentials_json = serde_json::from_str(&credentials_json_str)
+            .map_err(|e| error::Error::CredentialFormat(e.to_string()))?;
         let client = KeyManagementService::builder()
             .with_credentials(external_account::Builder::new(credentials_json).build()?)
             .build()

--- a/confidential_signer/src/kms_client.rs
+++ b/confidential_signer/src/kms_client.rs
@@ -17,15 +17,16 @@ pub struct Credentials {
     pub encryption_key_path: String,
 }
 
+#[derive(Default)]
 pub struct ClientFactory {}
 
 impl ClientFactory {
     pub fn new() -> Self {
-        Self {}
+        Self::default()
     }
 }
 
-const CONFIDENTIAL_CONFIG_STR: &'static str = r#"{{
+const CONFIDENTIAL_CONFIG_STR: &str = r#"{{
     "type": "external_account",
     "audience": "//iam.googleapis.com/{wip_provider_path}",
     "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
@@ -51,7 +52,7 @@ impl EncryptionBackend for Client {
             .set_plaintext(tonic::codegen::Bytes::from(src.to_vec()))
             .send()
             .await
-            .map_err(|e| error::Error::Encryption(e))?;
+            .map_err(error::Error::Encryption)?;
         Ok(response.ciphertext.into())
     }
 
@@ -63,7 +64,7 @@ impl EncryptionBackend for Client {
             .set_ciphertext(tonic::codegen::Bytes::from(src.to_vec()))
             .send()
             .await
-            .map_err(|e| error::Error::Decryption(e))?;
+            .map_err(error::Error::Decryption)?;
         Ok(response.plaintext.into())
     }
 }

--- a/confidential_signer_app/src/main.rs
+++ b/confidential_signer_app/src/main.rs
@@ -8,8 +8,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let conf = app::Config {
         listen_port: env::var("LISTEN_PORT")
             .ok()
-            .map(|s| s.parse().ok())
-            .flatten(),
+            .and_then(|s| s.parse().ok()),
     };
 
     let app = app::App::init(conf)?;

--- a/confidential_signer_mock/Cargo.toml
+++ b/confidential_signer_mock/Cargo.toml
@@ -4,12 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-# Workspace/local dependencies
 confidential_signer = { path = "../confidential_signer" }
-
-# CLI
+signer_core = { path = "../signer_core", features = ["test-utils"] }
 clap = { version = "4.5", features = ["derive"] }
 clap_derive = "4.5"
-
-# Serialization
-serde = { version = "1.0", features = ["derive"] }

--- a/confidential_signer_mock/src/app.rs
+++ b/confidential_signer_mock/src/app.rs
@@ -1,10 +1,6 @@
-use confidential_signer::{
-    rand_core,
-    signer_core::{EncryptionBackend, EncryptionBackendFactory, rpc::server::Server},
-    tokio,
-};
-use serde::{Deserialize, Serialize};
-use std::{convert::Infallible, io, net::SocketAddr};
+use confidential_signer::{rand_core, tokio};
+use signer_core::{mock::PassthroughFactory, rpc::server::Server};
+use std::{io, net::SocketAddr};
 
 pub struct App {}
 
@@ -27,46 +23,14 @@ impl std::fmt::Display for Error {
     }
 }
 
-#[derive(Debug)]
-struct Passthrough;
-
-impl EncryptionBackend for Passthrough {
-    type Error = Infallible;
-
-    async fn encrypt(&self, src: &[u8]) -> Result<Vec<u8>, Self::Error> {
-        Ok(Vec::from(src))
-    }
-
-    async fn decrypt(&self, src: &[u8]) -> Result<Vec<u8>, Self::Error> {
-        Ok(Vec::from(src))
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct DummyCredentials {} // serialized as empty object instead of null for unity
-
-struct PassthroughFactory;
-
-impl EncryptionBackendFactory for PassthroughFactory {
-    type Output = Passthrough;
-    type Credentials = DummyCredentials;
-    async fn try_new(&self, _cred: Self::Credentials) -> Result<Self::Output, Infallible> {
-        Ok(Passthrough)
-    }
-}
-
 impl App {
     pub async fn run(addr: &SocketAddr) -> Result<(), Error> {
-        // Start listening
         let listener = tokio::net::TcpListener::bind(addr).await?;
         loop {
-            // Accept TCP connection
             let (conn, _) = listener.accept().await?;
-
             tokio::spawn(async move {
-                // Create server
                 let mut srv = Server::new(PassthroughFactory, rand_core::OsRng);
-                // Serve connection
+
                 if let Err(err) = srv.serve_connection(conn).await {
                     eprintln!("{}", err);
                 }

--- a/confidential_signer_mock/src/app.rs
+++ b/confidential_signer_mock/src/app.rs
@@ -3,7 +3,6 @@ use confidential_signer::{
     signer_core::{EncryptionBackend, EncryptionBackendFactory, rpc::server::Server},
     tokio,
 };
-// use hyper_rustls::TlsAcceptor;
 use serde::{Deserialize, Serialize};
 use std::{convert::Infallible, io, net::SocketAddr};
 

--- a/nitro_signer/Cargo.toml
+++ b/nitro_signer/Cargo.toml
@@ -15,10 +15,10 @@ aws-smithy-runtime-api = { version = "1.7", features = ["client"] }
 rand_core = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 
-# aws-smithy-runtime will lock versions
-hyper = { version = "*", features = ["client", "http1", "http2"] }
-hyper-rustls = { version = "*", features = ["webpki-roots"] }
-rustls = { version = "*" }
+# pinned to match aws-smithy-runtime's hyper_014 adapter
+hyper = { version = "0.14", features = ["client", "http1", "http2"] }
+hyper-rustls = { version = "0.24", features = ["webpki-roots"] }
+rustls = { version = "0.21" }
 
 tokio = { version = "1.42", features = ["full"] }
 tokio-macros = "2.4"

--- a/nitro_signer/src/kms_client.rs
+++ b/nitro_signer/src/kms_client.rs
@@ -139,7 +139,7 @@ fn parse_enveloped_data<A>(src: &[u8]) -> Result<ParsedEnvelopedData, Error<A>> 
     let wrap = content_info
         .get_elem(
             &mut stream,
-            Some(0 | ale::ASN1_CONSTRUCTED | ale::ASN1_CONTEXT_SPECIFIC),
+            Some(ale::ASN1_CONSTRUCTED | ale::ASN1_CONTEXT_SPECIFIC),
         )
         .expect_some()?;
     // EnvelopedData
@@ -154,7 +154,7 @@ fn parse_enveloped_data<A>(src: &[u8]) -> Result<ParsedEnvelopedData, Error<A>> 
     // skip OriginatorInfo
     if let Some(oi) = contents.get_optional(
         &mut stream,
-        0 | ale::ASN1_CONSTRUCTED | ale::ASN1_CONTEXT_SPECIFIC,
+        ale::ASN1_CONSTRUCTED | ale::ASN1_CONTEXT_SPECIFIC,
     )? {
         oi.consume(&mut stream)?;
     }
@@ -230,7 +230,7 @@ fn parse_enveloped_data<A>(src: &[u8]) -> Result<ParsedEnvelopedData, Error<A>> 
     let encrypted_content = encrypted_content_info
         .get_elem(&mut stream, None)
         .expect_some()?;
-    let cipher_text = if encrypted_content.tag == 0 | ale::ASN1_CONTEXT_SPECIFIC {
+    let cipher_text = if encrypted_content.tag == ale::ASN1_CONTEXT_SPECIFIC {
         Vec::from(encrypted_content.get_bytes(&mut stream)?)
     } else if encrypted_content.tag & ale::ASN1_CONSTRUCTED != 0 {
         let mut data: Vec<u8> = Vec::with_capacity(stream.len());

--- a/nitro_signer_app/src/main.rs
+++ b/nitro_signer_app/src/main.rs
@@ -9,14 +9,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let conf = app::Config {
         proxy_port: env::var("PROXY_PORT")
             .ok()
-            .map(|s| s.parse().ok())
-            .flatten(),
-        proxy_cid: env::var("PROXY_CID").ok().map(|s| s.parse().ok()).flatten(),
+            .and_then(|s| s.parse().ok()),
+        proxy_cid: env::var("PROXY_CID").ok().and_then(|s| s.parse().ok()),
         endpoint: env::var("ENDPOINT").ok(),
         listen_port: env::var("LISTEN_PORT")
             .ok()
-            .map(|s| s.parse().ok())
-            .flatten(),
+            .and_then(|s| s.parse().ok()),
     };
 
     let app = app::App::init(conf)?;

--- a/nitro_signer_app/src/nsm.rs
+++ b/nitro_signer_app/src/nsm.rs
@@ -138,15 +138,16 @@ impl RngCore for SharedNSM {
     }
 
     fn try_fill_bytes(&mut self, mut dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        Ok(while !dest.is_empty() {
+        while !dest.is_empty() {
             let v = match self.0.get_random_vec() {
                 Ok(v) => v,
                 Err(err) => return Err(rand_core::Error::new(Box::new(err))),
             };
             let sz = std::cmp::min(v.len(), dest.len());
-            (&mut dest[..sz]).copy_from_slice(&v[..sz]);
+            dest[..sz].copy_from_slice(&v[..sz]);
             dest = &mut dest[sz..];
-        })
+        }
+        Ok(())
     }
 }
 

--- a/nitro_signer_app/src/nsm.rs
+++ b/nitro_signer_app/src/nsm.rs
@@ -138,7 +138,7 @@ impl RngCore for SharedNSM {
     }
 
     fn try_fill_bytes(&mut self, mut dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        Ok(while dest.len() != 0 {
+        Ok(while !dest.is_empty() {
             let v = match self.0.get_random_vec() {
                 Ok(v) => v,
                 Err(err) => return Err(rand_core::Error::new(Box::new(err))),
@@ -199,7 +199,7 @@ pub fn seed_rng(nsm: &NSM, mut bytes: usize) -> Result<(), Error> {
     let fd = fs::OpenOptions::new().write(true).open(DEV_RANDOM)?;
     while bytes != 0 {
         let chunk = nsm.get_random_vec()?;
-        if chunk.len() == 0 {
+        if chunk.is_empty() {
             return Err(Error::NSM(ErrorCode::InternalError));
         }
         let sz = cmp::min(chunk.len(), bytes);

--- a/nitro_signer_mock/Cargo.toml
+++ b/nitro_signer_mock/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 nitro_signer = { path = "../nitro_signer" }
+signer_core = { path = "../signer_core", features = ["test-utils"] }
 clap = { version = "4.5", features = ["derive"] }
 clap_derive = "4.5"
-serde = { version = "1.0", features = ["derive"] }

--- a/nitro_signer_mock/src/app.rs
+++ b/nitro_signer_mock/src/app.rs
@@ -1,10 +1,6 @@
-use nitro_signer::{
-    rand_core,
-    signer_core::{rpc::server::Server, EncryptionBackend, EncryptionBackendFactory},
-    tokio,
-};
-use serde::{Deserialize, Serialize};
-use std::{convert::Infallible, io, net::SocketAddr};
+use nitro_signer::{rand_core, tokio};
+use signer_core::{mock::PassthroughFactory, rpc::server::Server};
+use std::{io, net::SocketAddr};
 
 pub struct App {}
 
@@ -24,34 +20,6 @@ impl std::fmt::Display for Error {
         match self {
             Error::IO(error) => write!(f, "IO error: {}", error),
         }
-    }
-}
-
-#[derive(Debug)]
-struct Passthrough;
-
-impl EncryptionBackend for Passthrough {
-    type Error = Infallible;
-
-    async fn encrypt(&self, src: &[u8]) -> Result<Vec<u8>, Self::Error> {
-        Ok(Vec::from(src))
-    }
-
-    async fn decrypt(&self, src: &[u8]) -> Result<Vec<u8>, Self::Error> {
-        Ok(Vec::from(src))
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct DummyCredentials {} // serialized as empty object instead of null for unity
-
-struct PassthroughFactory;
-
-impl EncryptionBackendFactory for PassthroughFactory {
-    type Output = Passthrough;
-    type Credentials = DummyCredentials;
-    async fn try_new(&self, _cred: Self::Credentials) -> Result<Self::Output, Infallible> {
-        Ok(Passthrough)
     }
 }
 

--- a/signer_core/Cargo.toml
+++ b/signer_core/Cargo.toml
@@ -25,6 +25,9 @@ blake2 = "0.10"
 format-bytes = "0.3.0"
 serde_repr = "0.1.20"
 
+[features]
+test-utils = []
+
 [dev-dependencies]
 futures = "0.3"
 tokio = { version = "1.42", features = ["net", "macros", "rt"] }

--- a/signer_core/src/crypto.rs
+++ b/signer_core/src/crypto.rs
@@ -276,7 +276,7 @@ impl std::fmt::Display for Error {
             Error::Signature(_) => f.write_str("signature error"),
             Error::Bls(_) => f.write_str("BLST error"),
             Error::PopUnsupported => f.write_str("Proof of possession is not supported"),
-            Error::InvalidSigningVersion => f.write_str("Invalid signing     version"),
+            Error::InvalidSigningVersion => f.write_str("invalid signing version"),
         }
     }
 }

--- a/signer_core/src/crypto.rs
+++ b/signer_core/src/crypto.rs
@@ -198,7 +198,9 @@ impl KeyPair for PrivateKey {
             PrivateKey::Ed25519(val) => KeyPair::try_sign(val, msg, version)
                 .map(Into::into)
                 .map_err(Into::into),
-            PrivateKey::Bls(val) => Ok(val.try_sign(msg, version).unwrap().into()),
+            PrivateKey::Bls(val) => val.try_sign(msg, version)
+                .map(Into::into)
+                .map_err(Into::into),
         }
     }
 
@@ -218,7 +220,9 @@ impl PossessionProver for PrivateKey {
 
     fn try_prove(&self) -> Result<Self::Proof, Self::Error> {
         match self {
-            PrivateKey::Bls(val) => Ok(val.try_prove().unwrap().into()),
+            PrivateKey::Bls(val) => val.try_prove()
+                .map(Into::into)
+                .map_err(Into::into),
             _ => Err(Error::PopUnsupported),
         }
     }

--- a/signer_core/src/crypto.rs
+++ b/signer_core/src/crypto.rs
@@ -44,19 +44,14 @@ pub enum KeyType {
     Bls,
 }
 
-#[derive(Serialize_repr, Deserialize_repr, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize_repr, Deserialize_repr, Debug, Clone, PartialEq, Eq, Default)]
 #[repr(u8)]
 pub enum SigningVersion {
     V0 = 0,
     V1,
     V2,
+    #[default]
     Latest = 255,
-}
-
-impl Default for SigningVersion {
-    fn default() -> Self {
-        SigningVersion::Latest
-    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -118,7 +113,7 @@ impl KeyPair for ed25519_dalek::SigningKey {
     type Error = ed25519::signature::Error;
 
     fn public_key(&self) -> Self::PublicKey {
-        self.verifying_key().clone()
+        self.verifying_key()
     }
     fn try_sign(
         &self,
@@ -127,7 +122,7 @@ impl KeyPair for ed25519_dalek::SigningKey {
     ) -> Result<Self::Signature, Self::Error> {
         // Tezos uses Blake2b pre-hashing in conjunction with regular Ed25519/SHA512
         let d = Blake2b256::digest(msg);
-        Ok(Signer::try_sign(self, &d)?)
+        Signer::try_sign(self, &d)
     }
 }
 
@@ -199,8 +194,7 @@ impl KeyPair for PrivateKey {
                 .map(Into::into)
                 .map_err(Into::into),
             PrivateKey::Bls(val) => val.try_sign(msg, version)
-                .map(Into::into)
-                .map_err(Into::into),
+                .map(Into::into),
         }
     }
 
@@ -221,8 +215,7 @@ impl PossessionProver for PrivateKey {
     fn try_prove(&self) -> Result<Self::Proof, Self::Error> {
         match self {
             PrivateKey::Bls(val) => val.try_prove()
-                .map(Into::into)
-                .map_err(Into::into),
+                .map(Into::into),
             _ => Err(Error::PopUnsupported),
         }
     }
@@ -303,13 +296,14 @@ impl From<bls::Error> for Error {
     }
 }
 
+#[derive(Default)]
 pub struct Keychain {
     keys: Vec<PrivateKey>,
 }
 
 impl Keychain {
     pub fn new() -> Self {
-        Keychain { keys: Vec::new() }
+        Self::default()
     }
 
     pub fn import(&mut self, src: PrivateKey) -> usize {

--- a/signer_core/src/crypto/bls.rs
+++ b/signer_core/src/crypto/bls.rs
@@ -45,9 +45,9 @@ pub enum CipherSuite {
     ProofOfPossession(u8, Scheme),
 }
 
-impl Into<Vec<u8>> for CipherSuite {
-    fn into(self) -> Vec<u8> {
-        match self {
+impl From<CipherSuite> for Vec<u8> {
+    fn from(val: CipherSuite) -> Self {
+        match val {
             CipherSuite::Signature(g, scheme) => {
                 format_bytes!(b"BLS_SIG_BLS12381G{}_XMD:SHA-256_SSWU_RO_{}_", g, scheme)
             }

--- a/signer_core/src/crypto/ecdsa.rs
+++ b/signer_core/src/crypto/ecdsa.rs
@@ -142,7 +142,7 @@ where
     type Error = signature::Error;
 
     fn public_key(&self) -> Self::PublicKey {
-        VerifyingKey(self.verifying_key().clone())
+        VerifyingKey(*self.verifying_key())
     }
     fn try_sign(
         &self,
@@ -180,7 +180,7 @@ where
     where
         S: serde::Serializer,
     {
-        serializer.serialize_bytes(&self.0.to_encoded_point(true).as_bytes())
+        serializer.serialize_bytes(self.0.to_encoded_point(true).as_bytes())
     }
 }
 

--- a/signer_core/src/lib.rs
+++ b/signer_core/src/lib.rs
@@ -170,7 +170,7 @@ impl<E: EncryptionBackend> EncryptedSigner<E> {
     async fn decrypt(&self, src: &[u8]) -> Result<PrivateKey, Error<E::Error>> {
         match self.enc.decrypt(src).await {
             Ok(decrypted) => Ok(PrivateKey::try_from_cbor(&decrypted[..])?),
-            Err(err) => return Err(Error::Encryption(err)),
+            Err(err) => Err(Error::Encryption(err)),
         }
     }
 

--- a/signer_core/src/lib.rs
+++ b/signer_core/src/lib.rs
@@ -6,6 +6,8 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::future::Future;
 
 pub mod crypto;
+#[cfg(feature = "test-utils")]
+pub mod mock;
 pub mod rpc;
 pub(crate) mod serde_helper;
 

--- a/signer_core/src/mock.rs
+++ b/signer_core/src/mock.rs
@@ -1,0 +1,31 @@
+use crate::{EncryptionBackend, EncryptionBackendFactory};
+use serde::{Deserialize, Serialize};
+use std::convert::Infallible;
+
+#[derive(Debug)]
+pub struct Passthrough;
+
+impl EncryptionBackend for Passthrough {
+    type Error = Infallible;
+
+    async fn encrypt(&self, src: &[u8]) -> Result<Vec<u8>, Self::Error> {
+        Ok(Vec::from(src))
+    }
+
+    async fn decrypt(&self, src: &[u8]) -> Result<Vec<u8>, Self::Error> {
+        Ok(Vec::from(src))
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DummyCredentials {} // serialized as empty object instead of null for unity
+
+pub struct PassthroughFactory;
+
+impl EncryptionBackendFactory for PassthroughFactory {
+    type Output = Passthrough;
+    type Credentials = DummyCredentials;
+    async fn try_new(&self, _cred: Self::Credentials) -> Result<Self::Output, Infallible> {
+        Ok(Passthrough)
+    }
+}

--- a/signer_core/src/rpc.rs
+++ b/signer_core/src/rpc.rs
@@ -46,10 +46,7 @@ impl<T: std::error::Error> From<T> for Error {
     fn from(value: T) -> Self {
         Error {
             message: value.to_string(),
-            source: match value.source() {
-                Some(s) => Some(Box::new(Self::from(s))),
-                None => None,
-            },
+            source: value.source().map(|s| Box::new(Self::from(s))),
         }
     }
 }

--- a/signer_core/src/rpc.rs
+++ b/signer_core/src/rpc.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 pub mod client;
 pub mod server;
 
+pub const MAX_MESSAGE_SIZE: u32 = 2 * 1024 * 1024;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Request<C> {
     Initialize(C),

--- a/signer_core/src/rpc/client.rs
+++ b/signer_core/src/rpc/client.rs
@@ -146,7 +146,7 @@ where
         version: SigningVersion,
     ) -> Result<Signature, Error> {
         self.round_trip::<Signature>(Request::Sign {
-            handle: handle,
+            handle,
             message: msg.into(),
             version,
         })

--- a/signer_core/src/rpc/client.rs
+++ b/signer_core/src/rpc/client.rs
@@ -95,6 +95,13 @@ where
         self.socket.read_exact(&mut len_buf).await?;
         let len = u32::from_be_bytes(len_buf);
 
+        if len > crate::rpc::MAX_MESSAGE_SIZE {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("response size {} exceeds maximum {}", len, crate::rpc::MAX_MESSAGE_SIZE),
+            )
+            .into());
+        }
         self.buf.resize(len as usize, 0);
         self.socket.read_exact(&mut self.buf).await?;
 

--- a/signer_core/src/rpc/server.rs
+++ b/signer_core/src/rpc/server.rs
@@ -104,6 +104,13 @@ where
                 };
             }
             let len = u32::from_be_bytes(len_buf);
+            if len > crate::rpc::MAX_MESSAGE_SIZE {
+                break Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("message size {} exceeds maximum {}", len, crate::rpc::MAX_MESSAGE_SIZE),
+                )
+                .into());
+            }
             buf.resize(len as usize, 0);
             sock.read_exact(&mut buf).await?;
 

--- a/vsock/src/asio.rs
+++ b/vsock/src/asio.rs
@@ -170,13 +170,7 @@ impl AsRawFd for Datagram {
 pub struct Stream(AsyncFd<SyncStream>);
 
 fn is_in_progress(err: &Error) -> bool {
-    match err.raw_os_error() {
-        Some(code) => match code {
-            libc::EINPROGRESS | libc::EALREADY => true,
-            _ => false,
-        },
-        None => false,
-    }
+    matches!(err.raw_os_error(), Some(libc::EINPROGRESS | libc::EALREADY))
 }
 
 impl Stream {
@@ -193,7 +187,7 @@ impl Stream {
                 if let Some(err) = sock.0.get_ref().take_error()? {
                     break Err(err);
                 }
-                if let Ok(_) = sock.0.get_ref().peer_addr() {
+                if sock.0.get_ref().peer_addr().is_ok() {
                     break Ok(sock);
                 }
             },

--- a/vsock/src/lib.rs
+++ b/vsock/src/lib.rs
@@ -266,7 +266,7 @@ impl Write for Datagram {
     }
 }
 
-impl<'a> Write for &'a Datagram {
+impl Write for &Datagram {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         self.0.send(buf)
     }
@@ -364,7 +364,7 @@ impl Write for Stream {
     }
 }
 
-impl<'a> Write for &'a Stream {
+impl Write for &Stream {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         self.0.send(buf)
     }


### PR DESCRIPTION
## Summary

- Add `MAX_MESSAGE_SIZE` (2 MiB) guard to RPC server and client to reject oversized frames before allocation
- Replace `.unwrap()` calls in `confidential_signer` KMS credential parsing with proper `CredentialFormat` error propagation
- Fix all clippy warnings across the workspace (28 total): derivable impls, redundant closures, identity ops, needless borrows/returns, `matches!` macro, lifetime elision, `clone_on_copy`, `is_empty()`, `and_then()`, field init shorthand, `impl Into` → `impl From`, and more
- Fix typos in `Display` impls (`ale::Error::Encoding`, `crypto::Error::InvalidSigningVersion`) and remove dead commented-out import
- Unify all 9 workspace crates to `edition = "2021"` via `[workspace.package]`
- Deduplicate mock encryption backend (`Passthrough`, `PassthroughFactory`, `DummyCredentials`) into `signer_core::mock` behind a `test-utils` feature flag

## Test plan

- [x] `cargo check -p nitro_signer_mock -p confidential_signer_mock` passes
- [x] `cargo clippy --workspace` clean (0 warnings)
- [x] `cargo test -p signer_core` passes