### PR TITLE
Support BLS signing via SignDigest RPC

### DIFF
--- a/doc/rpc.md
+++ b/doc/rpc.md
@@ -163,9 +163,9 @@ SignWithResult = Signature
 
 Sign a pre-hashed digest with the key stored under the specified index. Unlike `Sign`, no blockchain-specific hashing (e.g., Blake2b) is applied before signing.
 
-Supported key types: Secp256k1, NistP256, Ed25519. BLS returns an error (`DigestSigningUnsupported`) because BLS signs full messages via hash-to-curve.
+Supported key types: Secp256k1, NistP256, Ed25519, BLS.
 
-For ECDSA (Secp256k1, NistP256), the digest is used directly as the prehash input — no additional hashing occurs. For Ed25519, the digest is treated as a standard Ed25519 message (SHA-512 hashing occurs internally per RFC 8032); this is inherent to the algorithm.
+For ECDSA (Secp256k1, NistP256), the digest is used directly as the prehash input — no additional hashing occurs. For Ed25519, the digest is treated as a standard Ed25519 message (SHA-512 hashing occurs internally per RFC 8032). For BLS, the input is treated as a message and signed using the Eth2 proof-of-possession cipher suite (`BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_`) with hash-to-curve applied internally.
 
 ```text
 SignDigestRequest = {

--- a/signer_core/src/crypto.rs
+++ b/signer_core/src/crypto.rs
@@ -219,7 +219,10 @@ impl KeyPair for PrivateKey {
             PrivateKey::Ed25519(val) => KeyPair::try_sign_digest(val, digest)
                 .map(Into::into)
                 .map_err(Into::into),
-            PrivateKey::Bls(_) => Err(Error::DigestSigningUnsupported),
+            PrivateKey::Bls(val) => val
+                .try_sign_digest(digest)
+                .map(Into::into)
+                .map_err(Into::into),
         }
     }
 
@@ -284,7 +287,6 @@ pub enum Error {
     Bls(bls::Error),
     PopUnsupported,
     InvalidSigningVersion,
-    DigestSigningUnsupported,
 }
 
 impl std::fmt::Display for Error {
@@ -295,9 +297,6 @@ impl std::fmt::Display for Error {
             Error::Bls(_) => f.write_str("BLST error"),
             Error::PopUnsupported => f.write_str("Proof of possession is not supported"),
             Error::InvalidSigningVersion => f.write_str("invalid signing version"),
-            Error::DigestSigningUnsupported => {
-                f.write_str("digest signing is not supported for this key type")
-            }
         }
     }
 }
@@ -596,13 +595,17 @@ mod tests {
     }
 
     #[test]
-    fn keychain_sign_digest_bls_unsupported() {
+    fn keychain_sign_digest_bls() {
         let mut keychain = Keychain::new();
         let pk = PrivateKey::generate(KeyType::Bls, &mut rand_core::OsRng).unwrap();
         let handle = keychain.import(pk);
 
-        let digest = Blake2b256::digest(b"text");
-        let err = keychain.try_sign_digest(handle, &digest).unwrap_err();
-        assert!(matches!(err, super::Error::DigestSigningUnsupported));
+        let msg = b"text";
+        let sig = unwrap_as!(
+            keychain.try_sign_digest(handle, msg).unwrap(),
+            Signature::Bls
+        );
+        let pub_key = unwrap_as!(keychain.public_key(handle).unwrap(), PublicKey::Bls);
+        pub_key.verify(msg, &sig, SigningVersion::V2).unwrap();
     }
 }

--- a/signer_core/src/crypto/bls.rs
+++ b/signer_core/src/crypto/bls.rs
@@ -258,8 +258,9 @@ impl KeyPair for SigningKey {
         }
     }
 
-    fn try_sign_digest(&self, _digest: &[u8]) -> Result<Self::Signature, Self::Error> {
-        Err(crypto::Error::DigestSigningUnsupported)
+    fn try_sign_digest(&self, digest: &[u8]) -> Result<Self::Signature, Self::Error> {
+        let cipher_suite: Vec<u8> = CipherSuite::Signature(2, Scheme::ProofOfPossession).into();
+        Ok(Signature(self.sign(digest, &cipher_suite, &[])))
     }
 }
 

--- a/signer_core/src/rpc/client.rs
+++ b/signer_core/src/rpc/client.rs
@@ -98,7 +98,11 @@ where
         if len > crate::rpc::MAX_MESSAGE_SIZE {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
-                format!("response size {} exceeds maximum {}", len, crate::rpc::MAX_MESSAGE_SIZE),
+                format!(
+                    "response size {} exceeds maximum {}",
+                    len,
+                    crate::rpc::MAX_MESSAGE_SIZE
+                ),
             )
             .into());
         }

--- a/signer_core/src/rpc/server.rs
+++ b/signer_core/src/rpc/server.rs
@@ -107,7 +107,11 @@ where
             if len > crate::rpc::MAX_MESSAGE_SIZE {
                 break Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    format!("message size {} exceeds maximum {}", len, crate::rpc::MAX_MESSAGE_SIZE),
+                    format!(
+                        "message size {} exceeds maximum {}",
+                        len,
+                        crate::rpc::MAX_MESSAGE_SIZE
+                    ),
                 )
                 .into());
             }


### PR DESCRIPTION
### Summary
Enable BLS keys to use the `SignDigest` RPC path by implementing `try_sign_digest` with the Eth2 proof-of-possession cipher suite, unifying all key types under a single signing RPC.
### Changes
- Implement `try_sign_digest` for BLS (`bls.rs`) using `BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_` cipher suite with hash-to-curve applied internally
- Update `PrivateKey::try_sign_digest` BLS arm to delegate instead of returning error (`crypto.rs`)
- Remove `Error::DigestSigningUnsupported` variant and its `Display` impl — no longer used by any algorithm
- Update test from `keychain_sign_digest_bls_unsupported` to `keychain_sign_digest_bls` verifying successful sign + verify round-trip
- Update `doc/rpc.md` to document BLS as a supported key type for `SignDigest`
- Minor `rustfmt` formatting in `rpc/client.rs` and `rpc/server.rs`