### PR TITLE
Add tee-signer image CI foundation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+target
+dist
+.idea
+.vscode
+.DS_Store
+*.eif
+*.pem
+*.key

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,29 +3,126 @@ name: Build and Test
 on:
   push:
     branches: [ "main" ]
+    tags: [ "v*" ]
   pull_request:
     branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always
+  REGISTRY: ghcr.io
+  NITRO_IMAGE: signatory-io/tee-signer-nitro
+  CONFIDENTIAL_SPACE_IMAGE: signatory-io/tee-signer-confidential-space
+
+permissions:
+  contents: read
 
 jobs:
-  build:
-
+  check:
+    name: Rust checks
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        rustflags: ""
-    - name: Build
-      run: cargo build --verbose
-    - name: Install tarpaulin
-      run: cargo install --features vendored-openssl cargo-tarpaulin
-    - name: Run tests with coverage
-      run: cargo tarpaulin --all-features --workspace --out html
-    - uses: actions/upload-artifact@v4
-      with:
-        name: test-coverage-report
-        path: ./tarpaulin-report.html
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt, clippy
+          rustflags: ""
+      - uses: extractions/setup-just@v3
+      - name: Check
+        run: just check
+
+  images:
+    name: Container images
+    runs-on: ubuntu-latest
+    needs: check
+    permissions:
+      attestations: write
+      artifact-metadata: write
+      contents: read
+      id-token: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Nitro image metadata
+        id: meta-nitro
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NITRO_IMAGE }}
+          tags: |
+            type=sha,prefix=,format=long
+            type=ref,event=tag
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Confidential Space image metadata
+        id: meta-confidential-space
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.CONFIDENTIAL_SPACE_IMAGE }}
+          tags: |
+            type=sha,prefix=,format=long
+            type=ref,event=tag
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build Nitro image
+        id: build-nitro
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/nitro_signer.Dockerfile
+          build-args: RELEASE=1
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta-nitro.outputs.tags }}
+          labels: ${{ steps.meta-nitro.outputs.labels }}
+
+      - name: Build Confidential Space image
+        id: build-confidential-space
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/confidential_signer.Dockerfile
+          build-args: RELEASE=1
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta-confidential-space.outputs.tags }}
+          labels: ${{ steps.meta-confidential-space.outputs.labels }}
+
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v4.1.1
+
+      - name: Sign Nitro image
+        if: github.event_name != 'pull_request'
+        run: cosign sign --yes "${REGISTRY}/${NITRO_IMAGE}@${DIGEST}"
+        env:
+          DIGEST: ${{ steps.build-nitro.outputs.digest }}
+
+      - name: Sign Confidential Space image
+        if: github.event_name != 'pull_request'
+        run: cosign sign --yes "${REGISTRY}/${CONFIDENTIAL_SPACE_IMAGE}@${DIGEST}"
+        env:
+          DIGEST: ${{ steps.build-confidential-space.outputs.digest }}
+
+      - name: Attest Nitro image
+        if: github.event_name != 'pull_request'
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.NITRO_IMAGE }}
+          subject-digest: ${{ steps.build-nitro.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attest Confidential Space image
+        if: github.event_name != 'pull_request'
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.CONFIDENTIAL_SPACE_IMAGE }}
+          subject-digest: ${{ steps.build-confidential-space.outputs.digest }}
+          push-to-registry: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2256,11 +2256,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",

--- a/ale/src/lib.rs
+++ b/ale/src/lib.rs
@@ -336,10 +336,10 @@ impl std::fmt::Display for Error {
             Error::EOS => f.write_str("unexpected end of stream"),
             Error::ValueTooLarge => f.write_str("value is too large"),
             Error::Encoding => f.write_str("invalid encoding"),
-            Error::Tag(tag) => write!(f, "unexpected tag: {:x}", tag),
+            Error::Tag(tag) => write!(f, "unexpected tag: {tag:x}"),
             Error::Infinite => f.write_str("infinite length"),
-            Error::Convert(err) => write!(f, "convert error: {}", err),
-            Error::Length(len) => write!(f, "invalid length: {}", len),
+            Error::Convert(err) => write!(f, "convert error: {err}"),
+            Error::Length(len) => write!(f, "invalid length: {len}"),
             Error::Overflow => f.write_str("overflow"),
         }
     }

--- a/confidential_signer/src/error.rs
+++ b/confidential_signer/src/error.rs
@@ -10,11 +10,11 @@ pub enum Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::Credentials(e) => write!(f, "Credentials error: {}", e),
-            Error::Auth(e) => write!(f, "Auth error: {}", e),
-            Error::Encryption(e) => write!(f, "Encryption error: {}", e),
-            Error::Decryption(e) => write!(f, "Decryption error: {}", e),
-            Error::CredentialFormat(msg) => write!(f, "Credential format error: {}", msg),
+            Error::Credentials(e) => write!(f, "Credentials error: {e}"),
+            Error::Auth(e) => write!(f, "Auth error: {e}"),
+            Error::Encryption(e) => write!(f, "Encryption error: {e}"),
+            Error::Decryption(e) => write!(f, "Decryption error: {e}"),
+            Error::CredentialFormat(msg) => write!(f, "Credential format error: {msg}"),
         }
     }
 }

--- a/confidential_signer_app/src/app.rs
+++ b/confidential_signer_app/src/app.rs
@@ -23,7 +23,7 @@ impl From<io::Error> for Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::IO(error) => write!(f, "IO error: {}", error),
+            Error::IO(error) => write!(f, "IO error: {error}"),
         }
     }
 }
@@ -50,7 +50,7 @@ impl App {
         );
 
         let listener = tokio::net::TcpListener::bind(addr).await?;
-        println!("Listening on {}", addr);
+        println!("Listening on {addr}");
         loop {
             let (conn, _) = listener.accept().await?;
 
@@ -59,7 +59,7 @@ impl App {
                 let mut srv = Server::new(cf, self.rng);
 
                 if let Err(err) = srv.serve_connection(conn).await {
-                    eprintln!("{}", err);
+                    eprintln!("{err}");
                 }
             });
         }

--- a/confidential_signer_mock/src/app.rs
+++ b/confidential_signer_mock/src/app.rs
@@ -18,7 +18,7 @@ impl From<io::Error> for Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::IO(error) => write!(f, "IO error: {}", error),
+            Error::IO(error) => write!(f, "IO error: {error}"),
         }
     }
 }
@@ -32,7 +32,7 @@ impl App {
                 let mut srv = Server::new(PassthroughFactory, rand_core::OsRng);
 
                 if let Err(err) = srv.serve_connection(conn).await {
-                    eprintln!("{}", err);
+                    eprintln!("{err}");
                 }
             });
         }

--- a/docker/confidential_signer.Dockerfile
+++ b/docker/confidential_signer.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=rust:1.88-slim
+ARG BASE_IMAGE=rust:1.95-trixie
 
 FROM $BASE_IMAGE AS builder
 

--- a/docker/nitro_signer.Dockerfile
+++ b/docker/nitro_signer.Dockerfile
@@ -1,8 +1,10 @@
 ARG BASE_IMAGE=public.ecr.aws/amazonlinux/amazonlinux:2
+ARG RUST_VERSION=1.95.0
 
 FROM $BASE_IMAGE AS builder
 
 ARG RELEASE
+ARG RUST_VERSION
 
 RUN yum install -y \
     gcc \
@@ -10,7 +12,7 @@ RUN yum install -y \
     tar \
     make
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain ${RUST_VERSION}
 
 COPY . /tee-signer
 RUN source $HOME/.cargo/env && cd tee-signer && cargo build ${RELEASE:+--release} --bin nitro_signer_app

--- a/justfile
+++ b/justfile
@@ -1,0 +1,49 @@
+set shell := ["bash", "-uc"]
+
+nitro_image := env_var_or_default("NITRO_IMAGE", "tee-signer-nitro")
+confidential_space_image := env_var_or_default("CONFIDENTIAL_SPACE_IMAGE", "tee-signer-confidential-space")
+image_tag := env_var_or_default("IMAGE_TAG", "dev")
+eif_output := env_var_or_default("EIF_OUTPUT", "dist/nitro-signer.eif")
+
+default:
+    @just --list
+
+fmt:
+    cargo fmt --check
+
+clippy:
+    cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+test:
+    cargo test --workspace --all-features
+
+build:
+    cargo build --workspace --all-targets --all-features
+
+build-release:
+    cargo build --release --bin nitro_signer_app --bin confidential_signer_app
+
+check: fmt clippy test build-release
+
+image-nitro:
+    docker build \
+        -f docker/nitro_signer.Dockerfile \
+        --build-arg RELEASE=1 \
+        -t "{{ nitro_image }}:{{ image_tag }}" \
+        .
+
+image-confidential-space:
+    docker build \
+        -f docker/confidential_signer.Dockerfile \
+        --build-arg RELEASE=1 \
+        -t "{{ confidential_space_image }}:{{ image_tag }}" \
+        .
+
+images: image-nitro image-confidential-space
+
+eif-nitro: image-nitro
+    command -v nitro-cli >/dev/null || { echo "nitro-cli is required to build a Nitro EIF" >&2; exit 1; }
+    mkdir -p "$(dirname "{{ eif_output }}")"
+    nitro-cli build-enclave \
+        --docker-uri "{{ nitro_image }}:{{ image_tag }}" \
+        --output-file "{{ eif_output }}"

--- a/nitro_signer/src/kms_client.rs
+++ b/nitro_signer/src/kms_client.rs
@@ -311,16 +311,16 @@ where
             Error::ZeroOutput => f.write_str("zero output"),
             Error::Ber(_) => f.write_str("BER error"),
             Error::ContentType(object_identifier) => {
-                write!(f, "unexpected content type: {}", object_identifier)
+                write!(f, "unexpected content type: {object_identifier}")
             }
-            Error::Version(cms_version) => write!(f, "unexpected CMS version: {:?}", cms_version),
+            Error::Version(cms_version) => write!(f, "unexpected CMS version: {cms_version:?}"),
             Error::Algorithm(object_identifier) => {
-                write!(f, "unexpected encryption algorithm: {}", object_identifier)
+                write!(f, "unexpected encryption algorithm: {object_identifier}")
             }
             Error::MissingData => f.write_str("some data is missing"),
             Error::Rsa(_) => f.write_str("RSA error"),
-            Error::KeySize(v) => write!(f, "invalid key size: {}", v),
-            Error::IvSize(v) => write!(f, "invalid iv size: {}", v),
+            Error::KeySize(v) => write!(f, "invalid key size: {v}"),
+            Error::IvSize(v) => write!(f, "invalid iv size: {v}"),
             Error::Unpad => f.write_str("unpad error"),
         }
     }

--- a/nitro_signer_app/src/app.rs
+++ b/nitro_signer_app/src/app.rs
@@ -40,9 +40,9 @@ impl From<io::Error> for Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::NSM(error) => write!(f, "NSM error: {}", error),
-            Error::RSA(error) => write!(f, "RSA error: {}", error),
-            Error::IO(error) => write!(f, "IO error: {}", error),
+            Error::NSM(error) => write!(f, "NSM error: {error}"),
+            Error::RSA(error) => write!(f, "RSA error: {error}"),
+            Error::IO(error) => write!(f, "IO error: {error}"),
         }
     }
 }
@@ -91,7 +91,7 @@ impl App {
         let listener = vsock::asio::Listener::bind(&listen_addr)?;
         loop {
             let (conn, addr) = listener.accept().await?;
-            println!("incoming connection from {}", addr);
+            println!("incoming connection from {addr}");
 
             let ccfg = client_conf.clone();
             let secm = self.secm.clone();
@@ -101,7 +101,7 @@ impl App {
                 let mut srv = Server::new(cf, secm);
 
                 if let Err(err) = srv.serve_connection(conn).await {
-                    eprintln!("{}", err);
+                    eprintln!("{err}");
                 }
             });
         }

--- a/nitro_signer_app/src/nsm.rs
+++ b/nitro_signer_app/src/nsm.rs
@@ -133,7 +133,7 @@ impl RngCore for SharedNSM {
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         if let Err(err) = self.try_fill_bytes(dest) {
-            panic!("NSM::fill_bytes(): {}", err);
+            panic!("NSM::fill_bytes(): {err}");
         }
     }
 

--- a/nitro_signer_mock/src/app.rs
+++ b/nitro_signer_mock/src/app.rs
@@ -18,7 +18,7 @@ impl From<io::Error> for Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::IO(error) => write!(f, "IO error: {}", error),
+            Error::IO(error) => write!(f, "IO error: {error}"),
         }
     }
 }
@@ -32,7 +32,7 @@ impl App {
                 let mut srv = Server::new(PassthroughFactory, rand_core::OsRng);
 
                 if let Err(err) = srv.serve_connection(conn).await {
-                    eprintln!("{}", err);
+                    eprintln!("{err}");
                 }
             });
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["clippy", "rustfmt"]

--- a/signer_core/src/crypto.rs
+++ b/signer_core/src/crypto.rs
@@ -219,10 +219,7 @@ impl KeyPair for PrivateKey {
             PrivateKey::Ed25519(val) => KeyPair::try_sign_digest(val, digest)
                 .map(Into::into)
                 .map_err(Into::into),
-            PrivateKey::Bls(val) => val
-                .try_sign_digest(digest)
-                .map(Into::into)
-                .map_err(Into::into),
+            PrivateKey::Bls(val) => val.try_sign_digest(digest).map(Into::into),
         }
     }
 
@@ -539,7 +536,7 @@ mod tests {
         let handle = keychain.import(pk);
 
         let pub_key = unwrap_as!(keychain.public_key(handle).unwrap(), PublicKey::Bls);
-        let sig = unwrap_as!(keychain.try_prove(handle).unwrap(), ProofOfPossession::Bls);
+        let ProofOfPossession::Bls(sig) = keychain.try_prove(handle).unwrap();
 
         pub_key.verify_pop(&sig).unwrap();
     }

--- a/signer_core/src/lib.rs
+++ b/signer_core/src/lib.rs
@@ -305,11 +305,8 @@ mod tests {
     impl EncryptionBackendFactory for PassthroughFactory {
         type Output = Passthrough;
         type Credentials = DummyCredentials;
-        fn try_new(
-            &self,
-            _cred: Self::Credentials,
-        ) -> impl std::future::Future<Output = Result<Self::Output, DummyErr>> {
-            async { Ok(Passthrough) }
+        async fn try_new(&self, _cred: Self::Credentials) -> Result<Self::Output, DummyErr> {
+            Ok(Passthrough)
         }
     }
 

--- a/signer_core/src/rpc.rs
+++ b/signer_core/src/rpc.rs
@@ -65,7 +65,7 @@ impl<T: std::error::Error> From<T> for Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.source {
-            Some(src) => write!(f, "{}: {}", &self.message, src),
+            Some(src) => write!(f, "{}: {src}", &self.message),
             None => f.write_str(&self.message),
         }
     }

--- a/signer_core/src/rpc/client.rs
+++ b/signer_core/src/rpc/client.rs
@@ -43,10 +43,10 @@ impl From<ciborium::ser::Error<std::io::Error>> for Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::IO(error) => write!(f, "IO error: {}", error),
-            Error::RPC(error) => write!(f, "RPC error: {}", error),
-            Error::Serialize(error) => write!(f, "serialization error: {}", error),
-            Error::Deserialize(error) => write!(f, "deserialization error: {}", error),
+            Error::IO(error) => write!(f, "IO error: {error}"),
+            Error::RPC(error) => write!(f, "RPC error: {error}"),
+            Error::Serialize(error) => write!(f, "serialization error: {error}"),
+            Error::Deserialize(error) => write!(f, "deserialization error: {error}"),
         }
     }
 }

--- a/signer_core/src/rpc/server.rs
+++ b/signer_core/src/rpc/server.rs
@@ -53,9 +53,9 @@ impl From<ciborium::ser::Error<std::io::Error>> for Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::IO(error) => write!(f, "IO error: {}", error),
-            Error::Serialize(error) => write!(f, "serialization error: {}", error),
-            Error::Deserialize(error) => write!(f, "deserialization error: {}", error),
+            Error::IO(error) => write!(f, "IO error: {error}"),
+            Error::Serialize(error) => write!(f, "serialization error: {error}"),
+            Error::Deserialize(error) => write!(f, "deserialization error: {error}"),
         }
     }
 }
@@ -108,8 +108,7 @@ where
                 break Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!(
-                        "message size {} exceeds maximum {}",
-                        len,
+                        "message size {len} exceeds maximum {}",
                         crate::rpc::MAX_MESSAGE_SIZE
                     ),
                 )
@@ -136,7 +135,7 @@ where
             Ok(req) => req,
             Err(err) => {
                 // return deserialization error to the client
-                println!("invalid request: {}", err);
+                println!("invalid request: {err}");
                 return RPCResult::<()>::Err(err.into())
                     .try_into_writer(buf)
                     .map_err(Into::into)

--- a/signer_core/src/serde_helper.rs
+++ b/signer_core/src/serde_helper.rs
@@ -17,7 +17,7 @@ impl<'a, const T: usize> Visitor<'a> for ByteArrayVisitor<T> {
     type Value = [u8; T];
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(formatter, "a byte array of size {}", T)
+        write!(formatter, "a byte array of size {T}")
     }
 
     fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
@@ -66,7 +66,8 @@ impl<'a> Visitor<'a> for BytesVisitor {
     type Value = Vec<u8>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(formatter, "a byte array of size {}", self.0)
+        let size = self.0;
+        write!(formatter, "a byte array of size {size}")
     }
 
     fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>

--- a/vsock/tests/vsock.rs
+++ b/vsock/tests/vsock.rs
@@ -45,10 +45,7 @@ mod linux {
                         conn.recv(&mut buf).unwrap();
                         conn.send(&buf).unwrap();
                     }
-                    Err(err) => {
-                        eprint!("error: {}", err);
-                        assert!(false);
-                    }
+                    Err(err) => panic!("error: {err}"),
                 }
                 count += 1;
                 if count == 2 {
@@ -113,14 +110,14 @@ mod linux {
 
                 let mut buf: [u8; 8] = [0; 8];
                 conn.read_exact(&mut buf).await.unwrap();
-                conn.write(&buf).await.unwrap();
+                conn.write_all(&buf).await.unwrap();
             },
             async {
                 let data: &[u8; 8] = b"datadata";
                 let mut client = Stream::connect(&SocketAddr::new(VMADDR_CID_LOCAL, loc.port()))
                     .await
                     .unwrap();
-                client.write(data).await.unwrap();
+                client.write_all(data).await.unwrap();
                 let mut buf: [u8; 8] = [0; 8];
                 let sz = client.read_exact(&mut buf).await.unwrap();
                 assert_eq!(&buf[0..sz], data);


### PR DESCRIPTION
## Summary
- add a justfile for local checks, release builds, Docker image builds, and Nitro EIF entrypoint
- pin Rust 1.95.0 and move the Confidential Space builder to rust:1.95-trixie
- replace the old coverage-only workflow with Rust checks plus Buildx image builds
- publish GHCR images from main/tags, sign pushed images with keyless cosign, and attach GitHub attestations
- update num-bigint-dig to clear the Rust future-incompatibility warning

## Local validation
- actionlint .github/workflows/build.yml
- just check
- NITRO_IMAGE=tee-signer-nitro IMAGE_TAG=publish-local just image-nitro
- CONFIDENTIAL_SPACE_IMAGE=tee-signer-confidential-space IMAGE_TAG=publish-local just image-confidential-space
- docker buildx build --file docker/nitro_signer.Dockerfile --build-arg RELEASE=1 --tag tee-signer-nitro:buildx-local --load .
- docker buildx build --file docker/confidential_signer.Dockerfile --build-arg RELEASE=1 --tag tee-signer-confidential-space:buildx-local --load .

## Notes
- Nitro EIF generation is wired locally through just eif-nitro, but not moved into CI yet. That should run on ephemeral AWS Nitro-capable infra via the private infra repo.